### PR TITLE
Replace django-ipware with python-ipware

### DIFF
--- a/pytracking/django.py
+++ b/pytracking/django.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from django.http import HttpResponseRedirect, Http404, HttpResponse
 from django.views.generic import View
-from ipware import get_client_ip
+from ipware.ipware import IpWare
 from pytracking.tracking import get_configuration, TRACKING_PIXEL, PNG_MIME_TYPE
 
 
@@ -103,8 +103,8 @@ def get_request_data(request):
     the client IP in X-Forwarded-For header).
     """
     user_agent = request.META.get("HTTP_USER_AGENT")
-    ip = get_client_ip(request)[0]
-    return {"user_agent": user_agent, "user_ip": ip}
+    ip = IpWare().get_client_ip(request.META)[0]
+    return {"user_agent": user_agent, "user_ip": str(ip)}
 
 
 def get_configuration_from_settings(settings_name="PYTRACKING_CONFIGURATION"):

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ EXTRA_REQUIRES = {
     "webhook": ["requests>=2.10.0"],
     "html": ["lxml>=4.4.0"],
     "crypto": ["cryptography>=2.0.0"],
-    "django": ["django-ipware>=2.0.0", "django>=1.11"],
+    "django": ["python-ipware>=0.9.0", "django>=1.11"],
 }
 
 ALL_REQUIRE = list(chain(*EXTRA_REQUIRES.values()))

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,4 +4,4 @@ pytest-django
 requests>=2.10.0
 lxml>=4.4.0
 cryptography>=2.0.0
-django-ipware>=2.0.0
+python-ipware==0.9.0

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -20,8 +20,6 @@ from .test_pytracking import (
 
 DEFAULT_ENCODED_URL_TO_TRACK = "https://www.bob.com/hello-world/?token=value%C3%A9%C3%A9%C3%A9"
 
-import ipware  # noqa
-
 # Must call configure before importing tracking_django
 from django.conf import settings
 from django.http import Http404


### PR DESCRIPTION
[django-ip](https://github.com/un33k/django-ipware/) works mainly by comparing strings where as [python-ipware](https://github.com/un33k/python-ipware) uses the Python IP Addresses

I noticed the difference due the this issue https://github.com/un33k/django-ipware/issues/88       


We also have the option to pass the actual IP Address instance, but I felt it would be a breaking change

